### PR TITLE
Fix composer autoloader configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,6 @@
         }
     ],
     "autoload": {
-        "psr-0": {
-            "Copyleaks": "src/"
-        }
+        "files": ["autoload.php"]
     }
 }


### PR DESCRIPTION
This change allows composer to correctly handle loading the classes automatically, removing the need for users to manually include the autoload.php file for this package.
