### PR TITLE
fixed the php 8.2 variable warnings

### DIFF
--- a/src/copyleaks.php
+++ b/src/copyleaks.php
@@ -223,7 +223,7 @@ class Copyleaks
 
     $this->verifyAuthToken($authToken);
 
-    $url = CopyleaksConfig::GET_API_SERVER_URI() . "/v3/downloads/${scanId}/export/${exportId}";
+    $url = CopyleaksConfig::GET_API_SERVER_URI() . "/v3/downloads/{$scanId}/export/{$exportId}";
 
     $authorization = "Authorization: Bearer $authToken->accessToken";
 


### PR DESCRIPTION
Fixed the warning "Using ${} in strings is deprecated."