### PR TITLE
Fix issue in require_once file name

### DIFF
--- a/src/Models/submissions/ai_detector/index.php
+++ b/src/Models/submissions/ai_detector/index.php
@@ -25,6 +25,6 @@
 
 namespace Copyleaks;
 
-include_once('CopyleaksAiDetectionSubmissionModel.php');
+include_once('CopyleaksAIDetectionSubmissionModel.php');
 include_once('CopyleaksNaturalLanguageSubmissionModel.php');
 include_once('CopyleaksSourceCodeSubmissionModel.php');


### PR DESCRIPTION
Use the correct file name CopyleaksAIDetectionSubmissionModel.php instead of CopyleaksAiDetectionSubmissionModel.php
<img width="914" alt="incorrect-file-name" src="https://github.com/user-attachments/assets/7523fd7e-5dd4-4540-86a1-a643e2747eab">
