### PR TITLE
added deprecation warning message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,15 @@
 {
   "name": "copyleaks/php-plagiarism-checker",
   "description": "Copyleaks detects online plagiarism and checks content distribution. Use Copyleaks to find out if textual content is original and where it has been used before. This package shows how to integrate with the Copyleaks cloud to search for copyright infringement.",
-  "minimum-stability": "dev",
+  "scripts": {
+        "post-install-cmd": [
+            "php deprecation-notice.php"
+        ],
+        "post-update-cmd": [
+            "php deprecation-notice.php"
+        ]
+    },
+    "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
     "php": ">=7.4.0"

--- a/demo/composer.json
+++ b/demo/composer.json
@@ -1,5 +1,13 @@
 {
   "name": "copyleaks/demo",
+  "scripts": {
+        "post-install-cmd": [
+            "php ../deprecation-notice.php"
+        ],
+        "post-update-cmd": [
+            "php ../deprecation-notice.php"
+        ]
+    },
   "authors": [
     {
       "name": "Bayan Abuawad",

--- a/deprecation-notice.php
+++ b/deprecation-notice.php
@@ -1,0 +1,22 @@
+<?php
+// ANSI color codes for terminal output
+$yellow = "\033[33m";
+$red = "\033[31m";
+$reset = "\033[0m";
+
+// Get package info from composer.json
+$composerJson = file_get_contents(__DIR__ . '/composer.json');
+$packageInfo = json_decode($composerJson, true);
+$packageName = $packageInfo['name'] ?? 'your-package';
+$packageVersion = $packageInfo['version'] ?? '1.0.0';
+
+echo <<<EOT
+
+{$yellow}================================================================{$reset}
+{$red}⚠️  DEPRECATION NOTICE: {$packageName} v{$packageVersion}{$reset}
+{$yellow}================================================================{$reset}
+{$yellow}AI Code Detection will be discontinued on August 29, 2025.{$reset}
+{$yellow}Please remove AI code detection integrations before the sunset date.{$reset}
+{$yellow}================================================================{$reset}
+
+EOT;

--- a/deprecation-notice.php
+++ b/deprecation-notice.php
@@ -8,7 +8,6 @@ $reset = "\033[0m";
 $composerJson = file_get_contents(__DIR__ . '/composer.json');
 $packageInfo = json_decode($composerJson, true);
 $packageName = $packageInfo['name'] ?? 'your-package';
-$packageVersion = $packageInfo['version'] ?? '1.0.0';
 
 echo <<<EOT
 


### PR DESCRIPTION
added deprecation warning for AI Code detection.
"AI Code Detection will be discontinued on August 29, 2025. Please remove AI code detection integrations before the sunset date." when updating the package version or installing the package.